### PR TITLE
feature

### DIFF
--- a/db/conf.d/my.cnf
+++ b/db/conf.d/my.cnf
@@ -1,6 +1,7 @@
 [mysqld]
 character-set-server=utf8
 collation-server=utf8_general_ci
+default_authentication_plugin=mysql_native_password
 
 [client]
 default-character-set=utf8

--- a/front/package.json
+++ b/front/package.json
@@ -18,7 +18,8 @@
     "react": "^16.8.6",
     "react-dom": "^16.8.6",
     "react-redux": "^7.1.3",
-    "redux": "^4.0.4"
+    "redux": "^4.0.4",
+    "redux-thunk": "^2.4.2"
   },
   "devDependencies": {
     "@babel/core": "^7.4.5",

--- a/front/src/components/AddScheduleDialog/container.jsx
+++ b/front/src/components/AddScheduleDialog/container.jsx
@@ -1,6 +1,7 @@
 import { connect } from "react-redux"
 import { addScheduleCloseDialog, addScheduleSetValue } from "../../redux/addSchedule/actions"
-import { asyncSchedulesAddItem } from "../../redux/schedules/effects"
+import { currentScheduleCloseDialog } from "../../redux/currentSchedule/actions"
+import { asyncSchedulesAddItem, asyncSchedulesDeleteItem } from "../../redux/schedules/effects"
 import { AddScheduleDialog } from "./presentation"
 
 const mapStateToProps = state => ({ schedule: state.addSchedule })
@@ -15,6 +16,10 @@ const mapDispatchToProps = dispatch => ({
   saveSchedule: schedule => {
     dispatch(asyncSchedulesAddItem(schedule))
     dispatch(addScheduleCloseDialog())
+  },
+  deleteItem: id => {
+    dispatch(asyncSchedulesDeleteItem(id))
+    dispatch(currentScheduleCloseDialog())
   }
 })
 

--- a/front/src/components/AddScheduleDialog/container.jsx
+++ b/front/src/components/AddScheduleDialog/container.jsx
@@ -1,6 +1,6 @@
 import { connect } from "react-redux"
 import { addScheduleCloseDialog, addScheduleSetValue } from "../../redux/addSchedule/actions"
-import { schedulesAddItem } from "../../redux/schedules/actions"
+import { asyncSchedulesAddItem } from "../../redux/schedules/effects"
 import { AddScheduleDialog } from "./presentation"
 
 const mapStateToProps = state => ({ schedule: state.addSchedule })
@@ -13,7 +13,7 @@ const mapDispatchToProps = dispatch => ({
     dispatch(addScheduleSetValue(value))
   },
   saveSchedule: schedule => {
-    dispatch(schedulesAddItem(schedule))
+    dispatch(asyncSchedulesAddItem(schedule))
     dispatch(addScheduleCloseDialog())
   }
 })

--- a/front/src/components/AddScheduleDialog/container.jsx
+++ b/front/src/components/AddScheduleDialog/container.jsx
@@ -1,5 +1,5 @@
 import { connect } from "react-redux"
-import { addScheduleCloseDialog, addScheduleSetValue } from "../../redux/addSchedule/actions"
+import { addScheduleCloseDialog, addScheduleSetValue, addScheduleStartEdit } from "../../redux/addSchedule/actions"
 import { currentScheduleCloseDialog } from "../../redux/currentSchedule/actions"
 import { asyncSchedulesAddItem, asyncSchedulesDeleteItem } from "../../redux/schedules/effects"
 import { AddScheduleDialog } from "./presentation"
@@ -20,6 +20,9 @@ const mapDispatchToProps = dispatch => ({
   deleteItem: id => {
     dispatch(asyncSchedulesDeleteItem(id))
     dispatch(currentScheduleCloseDialog())
+  },
+  setIsEditStart: () => {
+    dispatch(addScheduleStartEdit())
   }
 })
 

--- a/front/src/components/AddScheduleDialog/presentation.jsx
+++ b/front/src/components/AddScheduleDialog/presentation.jsx
@@ -1,24 +1,30 @@
 import React from 'react'
-import { Button, Dialog, DialogActions, DialogContent, Grid, IconButton, Input, TextField } from "@material-ui/core"
+import { Button, Dialog, DialogActions, DialogContent, Grid, IconButton, Input, TextField, Typography } from "@material-ui/core"
 import { LocationOnOutlined, NotesOutlined, AccessTime, Close } from "@material-ui/icons"
 import { DatePicker } from '@material-ui/pickers'
 import { withStyles } from '@material-ui/styles'
 import * as styles from "./style.css"
 
 const spacer = { margin: "4px 0" }
+
 const Title = withStyles({
-  root: { marginBottom: 32, fontSize: 22 }
+  root: {
+    fontSize: 22
+  }
 })(Input)
 
 export const AddScheduleDialog = ({
   schedule: {
     form: { title, location, description, date },
-    isDialogOpen
+    isDialogOpen,
+    isStartEdit
   },
   closeDialog,
   setSchedule,
-  saveSchedule
+  saveSchedule,
+  setIsEditStart
 }) => {
+  const isTitleInvalid = !title && isStartEdit
   return (
     <Dialog open={isDialogOpen} onClose={closeDialog} maxWidth="xs" fullWidth>
       <DialogActions>
@@ -34,7 +40,16 @@ export const AddScheduleDialog = ({
           placeholder='タイトルと日時を追加'
           value={title}
           onChange={e => setSchedule({ title: e.target.value })}
+          onBlur={setIsEditStart}
+          error={isTitleInvalid}
         />
+        <div className={styles.validation}>
+          {isTitleInvalid && (
+            <Typography variant="caption" component="div" color="error">
+              タイトルは必須です。
+            </Typography>
+          )}
+        </div>
         <Grid container spacing={1} alignItems="center" justifyContent='space-between'>
           <Grid item>
             <AccessTime />
@@ -82,11 +97,16 @@ export const AddScheduleDialog = ({
         </Grid>
       </DialogContent>
       <DialogActions>
-        <Button color='primary' variant="outlined" onClick={saveSchedule}>
+        <Button
+          color='primary'
+          variant="outlined"
+          onClick={saveSchedule}
+          disabled={!title}
+        >
           保存
         </Button>
       </DialogActions>
-    </Dialog>
+    </Dialog >
   )
 }
 

--- a/front/src/components/AddScheduleDialog/style.css
+++ b/front/src/components/AddScheduleDialog/style.css
@@ -1,3 +1,6 @@
 .closeButton{
   text-align: right;
 }
+.validation{
+  height:32px;
+}

--- a/front/src/components/CalendarBoard/container.jsx
+++ b/front/src/components/CalendarBoard/container.jsx
@@ -1,6 +1,7 @@
 import { connect } from "react-redux"
 import { addScheduleOpenDialog, addScheduleSetValue } from "../../redux/addSchedule/actions"
 import { currentScheduleOpenDialog, currentScheduleSetItem } from "../../redux/currentSchedule/actions"
+import { asyncSchedulesFetchItem } from "../../redux/schedules/effects"
 import { createCalendar } from "../../services/calendar"
 import { setSchedules } from "../../services/schedule"
 import CalendarBoard from "./presentation"
@@ -22,6 +23,10 @@ const mapDispatchToProps = dispatch => ({
 
     dispatch(currentScheduleSetItem(schedule))
     dispatch(currentScheduleOpenDialog())
+  },
+
+  fetchSchedule: month => {
+    dispatch(asyncSchedulesFetchItem(month))
   }
 })
 
@@ -35,6 +40,7 @@ const mergeProps = (stateProps, dispatchProps) => {
   return {
     ...stateProps,
     ...dispatchProps,
+    fetchSchedule: () => dispatchProps.fetchSchedule(month),
     calendar,
     month
   }

--- a/front/src/components/CalendarBoard/presentation.jsx
+++ b/front/src/components/CalendarBoard/presentation.jsx
@@ -4,6 +4,7 @@ import { ImageList, ImageListItem, Typography } from "@material-ui/core"
 import CalendarElement from '../CalendarElement'
 
 import * as styles from "./style.css"
+import { useEffect } from 'react'
 
 const days = ["日", "月", "火", "水", "木", "金", "土"]
 
@@ -11,9 +12,12 @@ const CalendarBoard = ({
   calendar,
   month,
   openAddScheduleDialog,
-  openCurrentScheduleDialog
+  openCurrentScheduleDialog,
+  fetchSchedule
 }) => {
-  console.log(calendar)
+  useEffect(() => {
+    fetchSchedule()
+  }, [])
   return (
     <div className={styles.container}>
       <ImageList className={styles.grid} cols={7} rowHeight="auto">

--- a/front/src/components/CurrentScheduleDialog/container.jsx
+++ b/front/src/components/CurrentScheduleDialog/container.jsx
@@ -1,5 +1,6 @@
 import { connect } from "react-redux"
 import { currentScheduleCloseDialog } from "../../redux/currentSchedule/actions"
+import { asyncSchedulesDeleteItem } from "../../redux/schedules/effects"
 import CurrentScheduleDialog from "./presentation"
 
 const mapStateToProps = state => ({ schedule: state.currentSchedule })
@@ -7,7 +8,24 @@ const mapStateToProps = state => ({ schedule: state.currentSchedule })
 const mapDispatchToProps = dispatch => ({
   closeDialog: () => {
     dispatch(currentScheduleCloseDialog())
+  },
+  deleteItem: id => {
+    dispatch(asyncSchedulesDeleteItem(id))
+    dispatch(currentScheduleCloseDialog())
   }
 })
 
-export default connect(mapStateToProps, mapDispatchToProps)(CurrentScheduleDialog)
+const mergeProps = (stateProps, dispatchProps) => ({
+  ...stateProps,
+  ...dispatchProps,
+  deleteItem: () => {
+    const { id } = stateProps.schedule.item
+    dispatchProps.deleteItem(id)
+  }
+})
+
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps,
+  mergeProps
+)(CurrentScheduleDialog)

--- a/front/src/components/CurrentScheduleDialog/presentation.jsx
+++ b/front/src/components/CurrentScheduleDialog/presentation.jsx
@@ -1,5 +1,5 @@
 import { Dialog, DialogActions, DialogContent, Grid, IconButton, Typography } from '@material-ui/core'
-import { Close, LocationOnOutlined, NotesOutlined } from '@material-ui/icons'
+import { Close, LocationOnOutlined, NotesOutlined, DeleteOutlineOutlined } from '@material-ui/icons'
 import React from 'react'
 import styles from "./style.css"
 
@@ -9,12 +9,16 @@ const spacer = (top, bottom) => ({
 
 const CurrentScheduleDialog = ({
   schedule: { item, isDialogOpen },
-  closeDialog
+  closeDialog,
+  deleteItem
 }) => {
   return (
     <Dialog open={isDialogOpen} onClose={closeDialog} maxWidth="xs" fullWidth>
       <DialogActions>
         <div className={styles.closeButton}>
+          <IconButton onClick={deleteItem} size="small">
+            <DeleteOutlineOutlined />
+          </IconButton>
           <IconButton onClick={closeDialog} size="small">
             <Close />
           </IconButton>

--- a/front/src/components/ErrorSnackbar/container.jsx
+++ b/front/src/components/ErrorSnackbar/container.jsx
@@ -1,0 +1,13 @@
+import { connect } from "react-redux"
+import ErrorSnackbar from "./presentation"
+import { schedulesResetError } from "../../redux/schedules/actions"
+
+const mapStateToProps = state => ({ error: state.schedules.error })
+
+const mapDispatchToProps = dispatch => ({
+  handleClose: () => {
+    dispatch(schedulesResetError())
+  }
+})
+
+export default connect(mapStateToProps, mapDispatchToProps)(ErrorSnackbar)

--- a/front/src/components/ErrorSnackbar/presentation.jsx
+++ b/front/src/components/ErrorSnackbar/presentation.jsx
@@ -1,0 +1,44 @@
+import { IconButton, Snackbar } from '@material-ui/core'
+import { Close, Warning } from '@material-ui/icons'
+import { makeStyles } from '@material-ui/core/styles'
+import React from 'react'
+
+const useStyles = makeStyles(theme => ({
+  message: {
+    display: "flex",
+    alignItems: "center"
+  },
+  icon: {
+    fontSize: 20
+  },
+  iconVariant: {
+    opacity: 0.9,
+    marginRight: theme.spacing(1)
+  }
+}))
+
+const ErrorSnackbar = ({ error, handleClose }) => {
+  const classes = useStyles()
+
+  return (
+    <Snackbar
+      open={!!error}
+      onClose={handleClose}
+      autoHideDuration={3000}
+      anchorOrigin={{ vertical: "bottom", horizontal: "right" }}
+      message={
+        <span className={classes.message}>
+          <Warning className={[classes.icon, classes.iconVariant].join(" ")} />
+          {error}
+        </span>
+      }
+      action={
+        <IconButton color='inherit' onClick={handleClose}>
+          <Close className={classes.icon} />
+        </IconButton>
+      }
+    />
+  )
+}
+
+export default ErrorSnackbar

--- a/front/src/components/Navigation/container.jsx
+++ b/front/src/components/Navigation/container.jsx
@@ -1,12 +1,17 @@
 import { connect } from "react-redux"
 import { calendarSetMonth } from "../../redux/calendar/actions"
+import { asyncSchedulesFetchItem } from "../../redux/schedules/effects"
 import { formatMonth, getMonth, getNextMonth, getPreviousMonth } from "../../services/calendar"
 import Navigation from "./presentation"
 
 const mapStateToProps = state => ({ calendar: state.calendar })
+
 const mapDispatchToProps = dispatch => ({
   setMonth: month => {
     dispatch(calendarSetMonth(month))
+  },
+  fetchItem: month => {
+    dispatch(asyncSchedulesFetchItem(month))
   }
 })
 
@@ -16,14 +21,20 @@ const mergeProps = (stateProps, dispatchProps) => ({
   setNextMonth: () => {
     const nextMonth = getNextMonth(stateProps.calendar)
     dispatchProps.setMonth(nextMonth)
+
+    dispatchProps.fetchItem(nextMonth)
   },
   setPreviousMonth: () => {
     const previousMonth = getPreviousMonth(stateProps.calendar)
     dispatchProps.setMonth(previousMonth)
+
+    dispatchProps.fetchItem(previousMonth)
   },
   setMonth: dayObj => {
     const month = formatMonth(dayObj)
     dispatchProps.setMonth(month)
+
+    dispatchProps.fetchItem(month)
   }
 })
 

--- a/front/src/index.jsx
+++ b/front/src/index.jsx
@@ -12,12 +12,13 @@ import rootReducer from "./redux/rootReducer";
 import Navigation from "./components/Navigation/container";
 import AddScheduleDialog from "./components/AddScheduleDialog/container";
 import CurrentScheduleDialog from "./components/CurrentScheduleDialog/container";
+import { applyMiddleware } from "redux";
+import thunk from "redux-thunk"
 
 
 dayjs.locale("ja")
 
-const store = createStore(rootReducer)
-
+const store = createStore(rootReducer, applyMiddleware(thunk))
 const App = () => (
   <Provider store={store}>
     <MuiPickersUtilsProvider utils={DayjsUtils}>

--- a/front/src/index.jsx
+++ b/front/src/index.jsx
@@ -14,6 +14,7 @@ import AddScheduleDialog from "./components/AddScheduleDialog/container";
 import CurrentScheduleDialog from "./components/CurrentScheduleDialog/container";
 import { applyMiddleware } from "redux";
 import thunk from "redux-thunk"
+import ErrorSnackbar from "./components/ErrorSnackbar/container";
 
 
 dayjs.locale("ja")
@@ -26,6 +27,7 @@ const App = () => (
       <CalendarBoard />
       <AddScheduleDialog />
       <CurrentScheduleDialog />
+      <ErrorSnackbar />
     </MuiPickersUtilsProvider>
   </Provider>
 );

--- a/front/src/redux/addSchedule/actions.js
+++ b/front/src/redux/addSchedule/actions.js
@@ -1,18 +1,22 @@
 // constants
-export const ADD_SCHEDULE_SET_VALUE="ADD_SCHEDULE_SET_VALUE"
+export const ADD_SCHEDULE_SET_VALUE = "ADD_SCHEDULE_SET_VALUE"
 export const ADD_SCHEDULE_OPEN_DIALOG = "ADD_SCHEDULE_OPEN_DIALOG"
 export const ADD_SCHEDULE_CLOSE_DIALOG = "ADD_SCHEDULE_CLOSE_DIALOG"
-
+export const ADD_SCHEDULE_START_EDIT = "ADD_SCHEDULE_START_EDIT"
 // actions
-export const addScheduleSetValue=payload=>({
+export const addScheduleSetValue = payload => ({
   type: ADD_SCHEDULE_SET_VALUE,
   payload
 })
 
-export const addScheduleOpenDialog=()=>({
+export const addScheduleOpenDialog = () => ({
   type: ADD_SCHEDULE_OPEN_DIALOG
 })
 
-export const addScheduleCloseDialog=()=>({
+export const addScheduleCloseDialog = () => ({
   type: ADD_SCHEDULE_CLOSE_DIALOG
+})
+
+export const addScheduleStartEdit = () => ({
+  type: ADD_SCHEDULE_START_EDIT
 })

--- a/front/src/redux/addSchedule/reducer.js
+++ b/front/src/redux/addSchedule/reducer.js
@@ -1,30 +1,34 @@
 import dayjs from "dayjs"
-import { 
+import {
   ADD_SCHEDULE_CLOSE_DIALOG,
   ADD_SCHEDULE_OPEN_DIALOG,
-  ADD_SCHEDULE_SET_VALUE 
-  } from "./actions"
+  ADD_SCHEDULE_SET_VALUE,
+  ADD_SCHEDULE_START_EDIT
+} from "./actions"
 
 const init = {
   form: {
     title: "",
     description: "",
     date: dayjs(),
-    location: ""
+    location: "",
+    isStartEdit: false
   },
   isDialogOpen: false
 }
 
-const addScheduleReducer = (state=init, action)=>{
-  const {type, payload}=action
+const addScheduleReducer = (state = init, action) => {
+  const { type, payload } = action
 
-  switch (type){
+  switch (type) {
     case ADD_SCHEDULE_SET_VALUE:
-      return {...state, form:{...state.form, ...payload}}
+      return { ...state, form: { ...state.form, ...payload } }
     case ADD_SCHEDULE_OPEN_DIALOG:
-      return {...state, isDialogOpen: true}
+      return { ...state, isDialogOpen: true }
     case ADD_SCHEDULE_CLOSE_DIALOG:
       return init
+    case ADD_SCHEDULE_START_EDIT:
+      return { ...state, isStartEdit: true }
     default:
       return state
   }

--- a/front/src/redux/schedules/actions.jsx
+++ b/front/src/redux/schedules/actions.jsx
@@ -1,4 +1,15 @@
 export const SCHEDULES_ADD_ITEM = "SCHEDULES_ADD_ITEM"
+export const SCHEDULES_FETCH_ITEM = "SCHEDULES_FETCH_ITEM"
+export const SCHEDULES_SET_LOADING = "SCHEDULES_SET_LOADING"
+
+export const schedulesFetchItem = payload => ({
+  type: SCHEDULES_FETCH_ITEM,
+  payload
+})
+
+export const schedulesSetLoading = () => ({
+  type: SCHEDULES_SET_LOADING
+})
 
 export const schedulesAddItem = payload => ({
   type: SCHEDULES_ADD_ITEM,

--- a/front/src/redux/schedules/actions.jsx
+++ b/front/src/redux/schedules/actions.jsx
@@ -1,6 +1,7 @@
 export const SCHEDULES_ADD_ITEM = "SCHEDULES_ADD_ITEM"
 export const SCHEDULES_FETCH_ITEM = "SCHEDULES_FETCH_ITEM"
 export const SCHEDULES_SET_LOADING = "SCHEDULES_SET_LOADING"
+export const SCHEDULES_DELETE_ITEM = "SCHEDULES_DELETE_ITEM"
 
 export const schedulesFetchItem = payload => ({
   type: SCHEDULES_FETCH_ITEM,
@@ -13,5 +14,10 @@ export const schedulesSetLoading = () => ({
 
 export const schedulesAddItem = payload => ({
   type: SCHEDULES_ADD_ITEM,
+  payload
+})
+
+export const schedulesDeleteItem = payload => ({
+  type: SCHEDULES_DELETE_ITEM,
   payload
 })

--- a/front/src/redux/schedules/actions.jsx
+++ b/front/src/redux/schedules/actions.jsx
@@ -3,6 +3,11 @@ export const SCHEDULES_FETCH_ITEM = "SCHEDULES_FETCH_ITEM"
 export const SCHEDULES_SET_LOADING = "SCHEDULES_SET_LOADING"
 export const SCHEDULES_DELETE_ITEM = "SCHEDULES_DELETE_ITEM"
 
+export const SCHEDULES_ASYNC_FAILURE = "SCHEDULES_ASYNC_FAILURE"
+export const SCHEDULES_RESET_ERROR = "SCHEDULES_RESET_ERROR"
+
+// actionss
+
 export const schedulesFetchItem = payload => ({
   type: SCHEDULES_FETCH_ITEM,
   payload
@@ -20,4 +25,13 @@ export const schedulesAddItem = payload => ({
 export const schedulesDeleteItem = payload => ({
   type: SCHEDULES_DELETE_ITEM,
   payload
+})
+
+export const schedulesAsyncFailure = error => ({
+  type: SCHEDULES_ASYNC_FAILURE,
+  error
+})
+
+export const schedulesResetError = () => ({
+  type: SCHEDULES_RESET_ERROR
 })

--- a/front/src/redux/schedules/effects.jsx
+++ b/front/src/redux/schedules/effects.jsx
@@ -1,5 +1,5 @@
-import { get, post } from "../../services/api"
-import { schedulesAddItem, schedulesFetchItem, schedulesSetLoading } from "./actions"
+import { deleteRequest, get, post } from "../../services/api"
+import { schedulesAddItem, schedulesDeleteItem, schedulesFetchItem, schedulesSetLoading } from "./actions"
 import { formatSchedule } from "../../services/schedule"
 
 export const asyncSchedulesFetchItem = ({ month, year }) => async dispatch => {
@@ -21,4 +21,15 @@ export const asyncSchedulesAddItem = schedule => async dispatch => {
 
   const newSchedule = formatSchedule(result)
   dispatch(schedulesAddItem(newSchedule))
+}
+
+export const asyncSchedulesDeleteItem = id => async (dispatch, getState) => {
+  dispatch(schedulesSetLoading())
+  const currentSchedules = getState().schedules.items
+
+  await deleteRequest(`schedules/${id}`)
+
+  // 成功したらローカルのstateを削除 filter
+  const newSchedules = currentSchedules.filter(s => s.id !== id)
+  dispatch(schedulesDeleteItem(newSchedules))
 }

--- a/front/src/redux/schedules/effects.jsx
+++ b/front/src/redux/schedules/effects.jsx
@@ -1,35 +1,52 @@
 import { deleteRequest, get, post } from "../../services/api"
-import { schedulesAddItem, schedulesDeleteItem, schedulesFetchItem, schedulesSetLoading } from "./actions"
+import { schedulesAddItem, schedulesAsyncFailure, schedulesDeleteItem, schedulesFetchItem, schedulesSetLoading } from "./actions"
 import { formatSchedule } from "../../services/schedule"
 
 export const asyncSchedulesFetchItem = ({ month, year }) => async dispatch => {
   dispatch(schedulesSetLoading())
 
-  const result = await get(`schedules?month=${month}&year=${year}`)
+  try {
 
-  const formatedSchedule = result.map(r => formatSchedule(r))
+    const result = await get(`schedules`)
+    // const result = await get(`schedules?month=${month}&year=${year}`)
 
-  dispatch(schedulesFetchItem(formatedSchedule))
+    const formatedSchedule = result.map(r => formatSchedule(r))
+
+    dispatch(schedulesFetchItem(formatedSchedule))
+  } catch (err) {
+    console.error(err)
+    dispatch(schedulesAsyncFailure(err.message))
+  }
 }
 
 export const asyncSchedulesAddItem = schedule => async dispatch => {
   // loading:trueにする
   dispatch(schedulesSetLoading())
 
-  const body = { ...schedule, date: schedule.date.toISOString() }
-  const result = await post("schedules", body)
+  try {
+    const body = { ...schedule, date: schedule.date.toISOString() }
+    const result = await post("schedules", body)
 
-  const newSchedule = formatSchedule(result)
-  dispatch(schedulesAddItem(newSchedule))
+    const newSchedule = formatSchedule(result)
+    dispatch(schedulesAddItem(newSchedule))
+  } catch (err) {
+    console.error(err)
+    dispatch(schedulesAsyncFailure(err.message))
+  }
 }
 
 export const asyncSchedulesDeleteItem = id => async (dispatch, getState) => {
   dispatch(schedulesSetLoading())
   const currentSchedules = getState().schedules.items
 
-  await deleteRequest(`schedules/${id}`)
+  try {
+    await deleteRequest(`schedules/${id}`)
 
-  // 成功したらローカルのstateを削除 filter
-  const newSchedules = currentSchedules.filter(s => s.id !== id)
-  dispatch(schedulesDeleteItem(newSchedules))
+    // 成功したらローカルのstateを削除 filter
+    const newSchedules = currentSchedules.filter(s => s.id !== id)
+    dispatch(schedulesDeleteItem(newSchedules))
+  } catch (err) {
+    console.error(err)
+    dispatch(schedulesAsyncFailure(err.message))
+  }
 }

--- a/front/src/redux/schedules/effects.jsx
+++ b/front/src/redux/schedules/effects.jsx
@@ -1,5 +1,5 @@
-import { get } from "../../services/api"
-import { schedulesFetchItem, schedulesSetLoading } from "./actions"
+import { get, post } from "../../services/api"
+import { schedulesAddItem, schedulesFetchItem, schedulesSetLoading } from "./actions"
 import { formatSchedule } from "../../services/schedule"
 
 export const asyncSchedulesFetchItem = ({ month, year }) => async dispatch => {
@@ -10,4 +10,15 @@ export const asyncSchedulesFetchItem = ({ month, year }) => async dispatch => {
   const formatedSchedule = result.map(r => formatSchedule(r))
 
   dispatch(schedulesFetchItem(formatedSchedule))
+}
+
+export const asyncSchedulesAddItem = schedule => async dispatch => {
+  // loading:trueにする
+  dispatch(schedulesSetLoading())
+
+  const body = { ...schedule, date: schedule.date.toISOString() }
+  const result = await post("schedules", body)
+
+  const newSchedule = formatSchedule(result)
+  dispatch(schedulesAddItem(newSchedule))
 }

--- a/front/src/redux/schedules/effects.jsx
+++ b/front/src/redux/schedules/effects.jsx
@@ -1,0 +1,13 @@
+import { get } from "../../services/api"
+import { schedulesFetchItem, schedulesSetLoading } from "./actions"
+import { formatSchedule } from "../../services/schedule"
+
+export const asyncSchedulesFetchItem = ({ month, year }) => async dispatch => {
+  dispatch(schedulesSetLoading())
+
+  const result = await get(`schedules?month=${month}&year=${year}`)
+
+  const formatedSchedule = result.map(r => formatSchedule(r))
+
+  dispatch(schedulesFetchItem(formatedSchedule))
+}

--- a/front/src/redux/schedules/reducer.jsx
+++ b/front/src/redux/schedules/reducer.jsx
@@ -1,5 +1,5 @@
 import dayjs from "dayjs"
-import { SCHEDULES_ADD_ITEM, SCHEDULES_FETCH_ITEM, SCHEDULES_SET_LOADING } from "./actions"
+import { SCHEDULES_ADD_ITEM, SCHEDULES_DELETE_ITEM, SCHEDULES_FETCH_ITEM, SCHEDULES_SET_LOADING } from "./actions"
 
 const init = {
   items: [],
@@ -21,6 +21,12 @@ const schedulesReducer = (state = init, action) => {
         isLoading: true
       }
     case SCHEDULES_FETCH_ITEM:
+      return {
+        ...state,
+        isLoading: false,
+        items: payload
+      }
+    case SCHEDULES_DELETE_ITEM:
       return {
         ...state,
         isLoading: false,

--- a/front/src/redux/schedules/reducer.jsx
+++ b/front/src/redux/schedules/reducer.jsx
@@ -1,13 +1,21 @@
 import dayjs from "dayjs"
-import { SCHEDULES_ADD_ITEM, SCHEDULES_DELETE_ITEM, SCHEDULES_FETCH_ITEM, SCHEDULES_SET_LOADING } from "./actions"
+import {
+  SCHEDULES_ADD_ITEM,
+  SCHEDULES_ASYNC_FAILURE,
+  SCHEDULES_DELETE_ITEM,
+  SCHEDULES_FETCH_ITEM,
+  SCHEDULES_RESET_ERROR,
+  SCHEDULES_SET_LOADING
+} from "./actions"
 
 const init = {
   items: [],
-  isLoading: false
+  isLoading: false,
+  error: null
 }
 
 const schedulesReducer = (state = init, action) => {
-  const { type, payload } = action
+  const { type, payload, error } = action
 
   switch (type) {
     case SCHEDULES_ADD_ITEM:
@@ -31,6 +39,16 @@ const schedulesReducer = (state = init, action) => {
         ...state,
         isLoading: false,
         items: payload
+      }
+    case SCHEDULES_ASYNC_FAILURE:
+      return {
+        ...state,
+        error
+      }
+    case SCHEDULES_RESET_ERROR:
+      return {
+        ...state,
+        error: null
       }
     default:
       return state

--- a/front/src/redux/schedules/reducer.jsx
+++ b/front/src/redux/schedules/reducer.jsx
@@ -13,7 +13,7 @@ const schedulesReducer = (state = init, action) => {
     case SCHEDULES_ADD_ITEM:
       return {
         state,
-        items: [...state.items, { ...payload, id: state.items.length + 1 }]
+        items: [...state.items, payload]
       }
     case SCHEDULES_SET_LOADING:
       return {

--- a/front/src/redux/schedules/reducer.jsx
+++ b/front/src/redux/schedules/reducer.jsx
@@ -1,16 +1,8 @@
 import dayjs from "dayjs"
-import { SCHEDULES_ADD_ITEM } from "./actions"
+import { SCHEDULES_ADD_ITEM, SCHEDULES_FETCH_ITEM, SCHEDULES_SET_LOADING } from "./actions"
 
 const init = {
-  items: [
-    {
-      id: 1,
-      title: "テスト",
-      date: dayjs(),
-      location: "会議室",
-      description: "経営戦略について"
-    }
-  ],
+  items: [],
   isLoading: false
 }
 
@@ -22,6 +14,17 @@ const schedulesReducer = (state = init, action) => {
       return {
         state,
         items: [...state.items, { ...payload, id: state.items.length + 1 }]
+      }
+    case SCHEDULES_SET_LOADING:
+      return {
+        ...state,
+        isLoading: true
+      }
+    case SCHEDULES_FETCH_ITEM:
+      return {
+        ...state,
+        isLoading: false,
+        items: payload
       }
     default:
       return state

--- a/front/src/services/api.jsx
+++ b/front/src/services/api.jsx
@@ -1,9 +1,21 @@
 const host = "http://localhost:8080/api"
 const url = path => `${host}/${path}`
 
+const header = {
+  headers: {
+    "Content-Type": "application/json"
+  }
+}
 export const get = async path => {
   const resp = await fetch(url(path))
   const result = await resp.json()
 
+  return result
+}
+
+export const post = async (path, body) => {
+  const options = { ...header, method: "POST", body: JSON.stringify(body) }
+  const resp = await fetch(url(path), options)
+  const result = await resp.json()
   return result
 }

--- a/front/src/services/api.jsx
+++ b/front/src/services/api.jsx
@@ -8,6 +8,9 @@ const header = {
 }
 export const get = async path => {
   const resp = await fetch(url(path))
+
+  checkError(resp.status)
+
   const result = await resp.json()
 
   return result
@@ -16,12 +19,25 @@ export const get = async path => {
 export const post = async (path, body) => {
   const options = { ...header, method: "POST", body: JSON.stringify(body) }
   const resp = await fetch(url(path), options)
+
+  checkError(resp.status)
+
   const result = await resp.json()
   return result
 }
 
 export const deleteRequest = async path => {
   const options = { method: "DELETE" }
-  await fetch(url(path), options)
+
+  const resp = await fetch(url(path), options)
+
+  checkError(resp.status)
+
   return
+}
+
+const checkError = status => {
+  if (status >= 400) {
+    throw new Error("エラーが発生しました。時間をおいて再度お試しください。")
+  }
 }

--- a/front/src/services/api.jsx
+++ b/front/src/services/api.jsx
@@ -19,3 +19,9 @@ export const post = async (path, body) => {
   const result = await resp.json()
   return result
 }
+
+export const deleteRequest = async path => {
+  const options = { method: "DELETE" }
+  await fetch(url(path), options)
+  return
+}

--- a/front/src/services/api.jsx
+++ b/front/src/services/api.jsx
@@ -1,0 +1,9 @@
+const host = "http://localhost:8080/api"
+const url = path => `${host}/${path}`
+
+export const get = async path => {
+  const resp = await fetch(url(path))
+  const result = await resp.json()
+
+  return result
+}

--- a/front/src/services/calendar.js
+++ b/front/src/services/calendar.js
@@ -28,8 +28,6 @@ export const isFirstDay = day=>day.date()===1
 export const createCalendar = month => {
   const firstDay = getMonth(month)
   const firstDayIndex = firstDay.day()
-  console.log(firstDay)
-  console.log(firstDayIndex)
 
   return Array(35)
     .fill(0)

--- a/front/src/services/schedule.jsx
+++ b/front/src/services/schedule.jsx
@@ -1,3 +1,4 @@
+import dayjs from "dayjs";
 import { isSameDay } from "./calendar";
 
 export const setSchedules = (calendar, schedules) =>
@@ -5,3 +6,8 @@ export const setSchedules = (calendar, schedules) =>
     date: c,
     schedules: schedules.filter(e => isSameDay(e.date, c))
   }))
+
+export const formatSchedule = schedule => ({
+  ...schedule,
+  date: dayjs(schedule.date)
+})


### PR DESCRIPTION
サーバーから予定を取得
サーバーに予定をpostする
削除機能を実装
[予定入力ダイアログにタイトルがない場合のvalidationを追加](https://github.com/gaia2013/calender-app/pull/5/commits/fd1e137ce8cde86a1b3ae1a7abc64d22429a491c)
[通信のエラーハンドリングを行う（コンソールログ出力まで）](https://github.com/gaia2013/calender-app/pull/5/commits/1bb46041a770857238b0ee27b7895130ee8cab2f)
[エラーを表示させる by Snackbar](https://github.com/gaia2013/calender-app/pull/5/commits/0ea4a297bc297c13fe62075eb97d7982b0551536)
